### PR TITLE
개인정보 페이지 구현 완료

### DIFF
--- a/views/infoEdit/InfoEdit.vue
+++ b/views/infoEdit/InfoEdit.vue
@@ -15,12 +15,19 @@
         <input v-model="email" type="email" placeholder="이메일">
       </div>
       <div class="field">
-        <label>비밀번호</label>
+        <label>기존 비밀번호</label>
         <input v-model="password" type="password" placeholder="비밀번호">
+        <div v-if="passwordIsBlank" class="ui pointing red basic label">
+          기존 비밀번호를 입력해주세요.
+        </div>
       </div>
       <div class="field">
-        <label>비밀번호 확인</label>
-        <input v-model="passwordCheck" type="password" placeholder="비밀번호 확인">
+        <label>새 비밀번호</label>
+        <input v-model="newPassword" type="password" placeholder="비밀번호">
+      </div>
+      <div class="field">
+        <label>새 비밀번호 확인</label>
+        <input v-model="newPasswordCheck" type="password" placeholder="비밀번호 확인">
         <div v-if="!isPasswordCorrect" class="ui pointing red basic label">
           비밀번호가 일치하지 않습니다.
         </div>
@@ -29,7 +36,7 @@
         <button
           type="submit"
           class="ui primary button"
-          :class="{disabled: isDisabledRegister}">
+          :class="{disabled: isDisabledEdit}">
           개인정보 수정
         </button>
       </div>
@@ -48,20 +55,28 @@
         nickName: '',
         email: '',
         password: '',
-        passwordCheck: '',
+        newPassword: '',
+        newPasswordCheck: '',
         isInputDisabled: true
       }
     },
     methods: {},
     computed: {
-      isDisabledRegister() {
+      // 버튼 활성화 여부
+      isDisabledEdit() {
         if (this.userId.length <= 0 || this.nickName.length <= 0 || this.email.length <= 0
-          || this.password.length <= 0 || this.passwordCheck.length <= 0  || !(this.password === this.passwordCheck)) {
+          || this.password.length <= 0  || !(this.newPassword === this.newPasswordCheck)) {
           return true;
         }
       },
+      //새 비밀번호와 새비밀번호 확인 일치 여부 확인
       isPasswordCorrect() {
-        if (this.password === this.passwordCheck) {
+        if (this.newPassword === this.newPasswordCheck) {
+          return true;
+        }
+      },
+      passwordIsBlank() {
+        if(this.password.length <= 0) {
           return true;
         }
       }
@@ -72,8 +87,6 @@
           this.userId = response.data.userId;
           this.nickName = response.data.nickName;
           this.email = response.data.email;
-          this.password = response.data.password;
-          this.passwordCheck = response.data.password;
           console.log(this.userId);
         })
     }
@@ -82,7 +95,7 @@
 
 <style scoped>
   .content {
-    margin: 0 35%;
+    margin: 5% 35%;
   }
   .button {
     width: 100%

--- a/views/infoEdit/InfoEdit.vue
+++ b/views/infoEdit/InfoEdit.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="content">
+    <h2 class="padding-30p">개인정보 수정</h2>
+    <form class="ui form">
+      <div class="field">
+        <label>아이디</label>
+        <input v-model="userId" type="text" :disabled="isInputDisabled" placeholder="아이디">
+      </div>
+      <div class="field">
+        <label>닉네임</label>
+        <input v-model="nickName" type="text" placeholder="닉네임">
+      </div>
+      <div class="field">
+        <label>이메일</label>
+        <input v-model="email" type="email" placeholder="이메일">
+      </div>
+      <div class="field">
+        <label>비밀번호</label>
+        <input v-model="password" type="password" placeholder="비밀번호">
+      </div>
+      <div class="field">
+        <label>비밀번호 확인</label>
+        <input v-model="passwordCheck" type="password" placeholder="비밀번호 확인">
+        <div v-if="!isPasswordCorrect" class="ui pointing red basic label">
+          비밀번호가 일치하지 않습니다.
+        </div>
+      </div>
+      <div class="field">
+        <button
+          type="submit"
+          class="ui primary button"
+          :class="{disabled: isDisabledRegister}">
+          개인정보 수정
+        </button>
+      </div>
+    </form>
+    <br/>
+  </div>
+</template>
+
+<script>
+  import axios from 'axios'
+
+  export default {
+    data() {
+      return {
+        userId: '',
+        nickName: '',
+        email: '',
+        password: '',
+        passwordCheck: '',
+        isInputDisabled: true
+      }
+    },
+    methods: {},
+    computed: {
+      isDisabledRegister() {
+        if (this.userId.length <= 0 || this.nickName.length <= 0 || this.email.length <= 0
+          || this.password.length <= 0 || this.passwordCheck.length <= 0  || !(this.password === this.passwordCheck)) {
+          return true;
+        }
+      },
+      isPasswordCorrect() {
+        if (this.password === this.passwordCheck) {
+          return true;
+        }
+      }
+    },
+    created() {
+      axios.get('http://localhost:8080/server/userInfo.json')
+        .then((response) => {
+          this.userId = response.data.userId;
+          this.nickName = response.data.nickName;
+          this.email = response.data.email;
+          this.password = response.data.password;
+          this.passwordCheck = response.data.password;
+          console.log(this.userId);
+        })
+    }
+  }
+</script>
+
+<style scoped>
+  .content {
+    margin: 0 35%;
+  }
+  .button {
+    width: 100%
+  }
+  .padding-30p {
+    padding: 0 30%;
+  }
+  a {
+    text-decoration: none;
+    transition: .06s;
+    transition-duration: 0.06s;
+    transition-property: all;
+    transition-timing-function: ease-in-out;
+    transition-delay: initial;
+  }
+  .login {
+    font-size: 13px;
+    text-align: center;
+    color: #98A8B9;
+  }
+  .login a {
+    padding-left: 0.25rem;
+    font-weight: 500;
+    color: #263747;
+    text-decoration: none;
+  }
+  .login a:hover {
+    color: #0078FF;
+  }
+  .login a:after {
+    transition-duration: 0.06s;
+    transition-property: all;
+    transition-timing-function: ease-in-out;
+    transition-delay: initial;
+    display: inline-block;
+    vertical-align: top;
+    margin-left: 0.25rem;
+    content: ' > ';
+  }
+  .login a:hover:after {
+    transform: translateX(0.25rem);
+  }
+</style>

--- a/views/infoEdit/InfoEditPage.vue
+++ b/views/infoEdit/InfoEditPage.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <header-menu></header-menu>
+    <info-edit></info-edit>
+  </div>
+</template>
+
+<script>
+  import HeaderMenu from '@/components/header/HeaderMenu'
+  import InfoEdit from '@/pc/views/infoEdit/InfoEdit'
+
+  export default {
+    components: {
+      HeaderMenu,
+      InfoEdit
+    }
+  }
+</script>


### PR DESCRIPTION
<img width="936" alt="개인정보 수정 페이지" src="https://user-images.githubusercontent.com/38181303/59017483-96df8a80-887e-11e9-9c8f-71e3d5572682.png">

* 개인정보 수정 페이지
    - 아이디 변경 불가 (readonly 구현)
    - 닉네임, 이메일, 비밀번호 변경 가능
    - 새로운 비밀번호 변경시 '새 비밀번호 확인' 입력 필수

<img width="798" alt="개인정보 수정_5가지 상태" src="https://user-images.githubusercontent.com/38181303/59017349-4cf6a480-887e-11e9-9d72-edb5ae01cd4d.png">

* 개인정보 수정 페이지 : 5가지 상태
    1.  개인정보 수정 페이지 첫화면 (기존 비밀번호 입력 필수 안내 및 버튼 비활성화)
    2.  기존 비밀번호 입력 시 화면 
        (기존 비밀번호를 입력했을 시 버튼 활성화, 기존 비밀번호 일치 여부는 서버에서 확인  후 알림)
    3. 기존 비밀번호 입력 & 이메일(닉네임) 변경 (버튼 활성)
    4. 기존 비밀번호 입력 & 새로운 비밀번호와 비밀번호 확인 일치 (버튼 활성화)
    5. 기존비밀번호 입력 & 새로운 비밀번호와 비밀번호 확인 불일치 (버튼 비활성화) 

