### PR TITLE
학생용 강의 추가 페이지 구현

### DIFF
--- a/components/lecture/LectureList.vue
+++ b/components/lecture/LectureList.vue
@@ -31,7 +31,10 @@
     },
     methods: {
       apply: function () {
-        confirm('선택하신 강좌를 신청하시겠습니까?');
+        if(confirm('선택하신 강좌를 신청하시겠습니까?')) {
+          // axios : 강좌 insert api
+          alert('선택하신 강좌가 정상적으로 신청되었습니다.')
+        }
       }
     }
   }

--- a/components/lecture/LectureList.vue
+++ b/components/lecture/LectureList.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="ui middle aligned divided list">
+    <div class="item" v-for="lecture in lectures">
+      <shadow-box>
+        <lecture-item v-bind:lecture="lecture"></lecture-item>
+        <v-btn
+          outline
+          color="info"
+          class="addBtn right"
+          v-on:click="apply"
+        >신청</v-btn>
+      </shadow-box>
+    </div>
+  </div>
+</template>
+<script>
+  import LectureItem from "@/components/lecture/LectureItem"
+  import ShadowBox from "@/components/lecture/ShadowBox"
+
+  export default {
+    components: {
+      LectureItem,
+      ShadowBox
+    },
+    props: {
+      lectures: {
+        type: Array,
+        required: true,
+        description: "lecture list"
+      }
+    },
+    methods: {
+      apply: function () {
+        confirm('선택하신 강좌를 신청하시겠습니까?');
+      }
+    }
+  }
+</script>
+<style>
+  .ui.list > .item {
+    padding: 0;
+  }
+  .item:hover .content {
+    color: #0078FF;
+  }
+  .margin-left-150 {
+    margin-left: 150px
+  }
+  .margin-right-150 {
+    margin-right: 150px
+  }
+  .right {
+    float: right;
+  }
+  .ui.list {
+    margin: 1em 15%;
+    border-top: 0.0625rem solid rgba(50,50,124,0.12);
+  }
+  .v-input--selection-controls {
+    float: right;
+    margin-top: -60px;
+  }
+  .addBtn {
+    margin-top: -7%;
+    font-weight: 700;
+  }
+</style>

--- a/views/lectureList/LectureAddPage.vue
+++ b/views/lectureList/LectureAddPage.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <header-menu></header-menu>
+    <h1 class="title">강의 목록</h1>
+    <lecture-list :lectures="lectures"></lecture-list>
+  </div>
+</template>
+
+<script>
+  import HeaderMenu from '@/components/header/HeaderMenu'
+  import LectureList from '@/pc/components/lecture/LectureList'
+  import axios from 'axios'
+
+  export default {
+    components: {
+      HeaderMenu,
+      LectureList
+    },
+    data() {
+      return {
+        lectures: []
+      }
+    },
+    created() {
+      axios.get('http://localhost:8080/server/lectures.json')
+        .then((response) => {
+          this.lectures = response.data;
+          console.log(this.lectures);
+        });
+    }
+  }
+</script>
+
+<style scoped>
+  h1 {
+    margin: 0;
+  }
+  .title {
+    padding: 2% 15% 2% 16%;
+    font-size: 25px;
+    font-weight: 800;
+  }
+
+</style>


### PR DESCRIPTION
<img width="935" alt="학생용 강의 추가 페이지" src="https://user-images.githubusercontent.com/38181303/59564732-425dbb80-9085-11e9-98e0-97a95b54e2ed.PNG">

* 활성화된 강의 목록 출력
* 각 강의 우측에 '신청' 버튼
* 버튼 클릭 후 안내창 구현